### PR TITLE
ci: Test Emacs 30.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
         emacs_version:
           - 28.2
           - 29.4
+          - 30.2
           - snapshot
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Add CI test with the latest stable version of Emacs.